### PR TITLE
fix(#6212): fix category filter regex check

### DIFF
--- a/src/filtertransdialog.cpp
+++ b/src/filtertransdialog.cpp
@@ -972,7 +972,7 @@ bool mmFilterTransactionsDialog::mmIsValuesCorrect() const
 
     if (mmIsCategoryChecked())
     {
-        const auto& value = categoryComboBox_->GetValue();
+        const auto& value = categoryComboBox_->mmGetPattern();
         if (value.empty()) {
             mmErrorDialogs::ToolTip4Object(categoryComboBox_, _("Empty value"), _("Category"), wxICON_ERROR);
             return false;


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).
